### PR TITLE
feat: refine function getFonts to be able to remove font file extensions (e.g., .ttf, .shx) from font names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-parser",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "AutoCAD MText parser written in TypeScript",
   "type": "module",
   "main": "dist/parser.cjs.js",

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1234,4 +1234,28 @@ describe('getFonts', () => {
     const result = getFonts(mtext);
     expect(result).toEqual(new Set(['simsun', 'arial', 'romans', 'simhei', 'simkai']));
   });
+
+  it('should preserve font extensions when removeExtension is false', () => {
+    const mtext = '\\fArial.ttf|Hello \\fTimes New Roman.otf|World';
+    const result = getFonts(mtext, false);
+    expect(result).toEqual(new Set(['arial.ttf', 'times new roman.otf']));
+  });
+
+  it('should remove font extensions when removeExtension is true', () => {
+    const mtext = '\\fArial.ttf|Hello \\fTimes New Roman.otf|World';
+    const result = getFonts(mtext, true);
+    expect(result).toEqual(new Set(['arial', 'times new roman']));
+  });
+
+  it('should handle various font extensions', () => {
+    const mtext = '\\fFont1.ttf|Text1 \\fFont2.otf|Text2 \\fFont3.woff|Text3 \\fFont4.shx|Text4';
+    const result = getFonts(mtext, true);
+    expect(result).toEqual(new Set(['font1', 'font2', 'font3', 'font4']));
+  });
+
+  it('should not remove non-font extensions', () => {
+    const mtext = '\\fFont1.txt|Text1 \\fFont2.doc|Text2';
+    const result = getFonts(mtext, true);
+    expect(result).toEqual(new Set(['font1.txt', 'font2.doc']));
+  });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -251,24 +251,29 @@ export function hasInlineFormattingCodes(text: string): boolean {
 
 /**
  * Extracts all unique font names used in an MText string.
- * This function searches for font commands in the format \f{fontname}| and returns a set of unique font names.
+ * This function searches for font commands in the format \f{fontname}| or \f{fontname}; and returns a set of unique font names.
  * Font names are converted to lowercase to ensure case-insensitive uniqueness.
  *
  * @param mtext - The MText string to analyze for font names
+ * @param removeExtension - Whether to remove font file extensions (e.g., .ttf, .shx) from font names. Defaults to false.
  * @returns A Set containing all unique font names found in the MText string, converted to lowercase
  * @example
  * ```ts
- * const mtext = "\\fArial|Hello\\fTimes New Roman|World";
- * const fonts = getFonts(mtext);
+ * const mtext = "\\fArial.ttf|Hello\\fTimes New Roman.otf|World";
+ * const fonts = getFonts(mtext, true);
  * // Returns: Set(2) { "arial", "times new roman" }
  * ```
  */
-export function getFonts(mtext: string) {
+export function getFonts(mtext: string, removeExtension: boolean = false) {
   const fonts: Set<string> = new Set();
   const regex = /\\[fF](.*?)[;|]/g;
 
   [...mtext.matchAll(regex)].forEach(match => {
-    fonts.add(match[1].toLowerCase());
+    let fontName = match[1].toLowerCase();
+    if (removeExtension) {
+      fontName = fontName.replace(/\.(ttf|otf|woff|shx)$/, '');
+    }
+    fonts.add(fontName);
   });
 
   return fonts;


### PR DESCRIPTION
…ons (e.g., .ttf, .shx) from font names